### PR TITLE
Add 'Your Voice in Software' essay

### DIFF
--- a/src/content/blog/your-voice-in-software.md
+++ b/src/content/blog/your-voice-in-software.md
@@ -1,0 +1,100 @@
+---
+title: 'Your Voice in Software'
+publishDate: 'Aug 30 2026'
+excerpt: 'Most software is judged on whether it works. The software that stays with us carries the presence of people who cared how working should feel — taste becomes style, style becomes voice.'
+tags:
+  - software
+  - aesthetics
+---
+
+You’re most likely reading this essay through software. I don’t think anybody is printing it on A4-sized sheets to read. Although that would be a beautiful gesture, and it would make me grateful.
+
+This interaction between you and me is made possible through software. So are increasingly large parts of your life: how you work, find your way home, speak to your friends, discover music, order dinner, and occasionally waste twenty minutes watching videos you never intended to watch.
+
+Software has become an immovable element of modern life. Yet we rarely stop to ask what kind of software we want surrounding us.
+
+Being a software engineer, I’ve been thinking about what makes software good. Is good software simply software that works? How much more should we expect from it?
+
+There are many kinds of software.
+
+There is the point-of-sale system your local bookstore uses to print invoices. There is the mobile application you use to scan a QR code at a restaurant so you can finally eat after a long day. There is the clicker game that shows you a hundred advertisements before allowing you to grow wheat on your digitally owned farmland.
+
+All of these products accomplish something. Some may make millions in annual revenue. They might be dependable, commercially successful, and entirely adequate.
+
+And then there is software through which you can feel the presence of the people who made it.
+
+It has a voice.
+
+What does that mean?
+
+Software is usually treated as an instrument whose value lies in what it accomplishes. But the software that matters to us often carries the unmistakable presence of people who cared about how accomplishing something should feel.
+
+This feeling is not simply visual beauty. Beautiful software can be frustrating to use. Plain software can feel wonderful. Nor is it polish. A highly polished product can still feel anonymous, while a small and imperfect application can possess enormous character.
+
+Voice emerges from choices.
+
+A watch only needs to tell the time. A coat only needs to keep you warm. Perfume does not need to evoke a memory of rain falling on concrete, an old library, or a person you once loved. Yet we have never been satisfied with these objects merely performing their functions.
+
+We use them to communicate something about ourselves. Their makers use them to communicate something too.
+
+The same function can be fulfilled through thousands of possible forms. Style appears in the choices between them: what is included, what is omitted, what is exaggerated, and what is treated with restraint. Over time, a consistent pattern of choices becomes recognizable. It starts to feel like somebody.
+
+Software has different materials, but the act is similar.
+
+Its materials are speed, sequence, language, sound, motion, hierarchy, feedback, permission, and friction. A software maker chooses what should happen immediately and what should require deliberation. They decide whether an error should punish you or help you recover. They decide which actions deserve celebration, which details should disappear, and what the user should be trusted to understand.
+
+None of these decisions are inevitable.
+
+There are countless ways to build an application that technically performs the same task. The decisions made among those possibilities reveal what the people behind the software consider important.
+
+Taste is expressed through selection. Style is the pattern left behind by those selections. Voice is what allows us to sense the people behind the pattern.
+
+This is why software can feel good in a way that exceeds convenience. Sometimes an interaction responds exactly when you expect it to. An animation gives an action weight without making you wait. A complicated process becomes simple, but not condescending. Something that required visible effort suddenly feels effortless.
+
+People sometimes describe this feeling as magic.
+
+But magic in software does not come from adding spectacle. It usually comes from extreme attention ending in the apparent absence of effort. The complexity remains, but somebody has carried it on your behalf.
+
+The original iPhone is an obvious example. Its significance was not merely that it combined a phone, a music player, and an internet device. Many of its interactions were designed to make computation feel direct. You touched the thing you wanted to move. The interface appeared to respond to your hand rather than to an abstract instruction.
+
+That experience represented a particular belief about what computers should feel like.
+
+The same can be seen, at smaller scales, in products such as Airbnb, Linear, or Flighty. What gives these products character is not simply attractive typography or animation. It is the accumulation of decisions about what deserves attention, what can be removed, and how much complexity the product should absorb before it reaches the user.
+
+Of course, naming fashionable software companies is not enough to prove that software has a voice. Branding can imitate personality. Animation can become decoration. Polish can conceal indifference.
+
+A humble bookstore system could possess more voice than a celebrated consumer application. It might understand the bookseller’s work so intimately that every interaction communicates care. A database can express restraint. A programming language can express beliefs about how people should think. Infrastructure can be beautiful through reliability precisely because it knows when to disappear.
+
+Voice does not require software to be loud.
+
+It requires decisions that arise from something deeper than convention.
+
+That becomes difficult as software companies grow. Software is rarely the work of one person. It is made by engineers, designers, writers, researchers, product managers, executives, and many others. Each brings different priorities. The product is also shaped by deadlines, competitors, technical limitations, customer demands, analytics, and the need to make money.
+
+Under these pressures, voice can be averaged away.
+
+A decision that nobody strongly believes in can survive because a metric supports it. A strange but meaningful detail can disappear because it is difficult to justify.
+
+This does not make commerce the enemy of art. Some of the most expressive objects ever made were also made to be sold. Profit does not remove the possibility of care, just as beauty does not prove its presence.
+
+The more useful distinction is between software created entirely through optimization and software that still contains human judgment.
+
+Optimization asks what produces the desired result. Judgment also asks what kind of experience is worth creating. The answer may not always be measurable.
+
+Why should any of this matter?
+
+Perhaps it does not matter for every piece of software. Some systems should be quiet, predictable, and almost invisible. Nobody needs a payment processor to express itself flamboyantly while moving their money.
+
+But restraint is itself a choice. Reliability can be an expression of respect. Even software that disappears influences how confidently, calmly, or anxiously we move through the world.
+
+It determines whether an action feels obvious or confusing, empowering or restrictive, humane or indifferent. And because we spend so much of our lives inside these systems, those feelings accumulate. Software participates in shaping the texture of ordinary life.
+
+That is why putting yourself into software is not a superficial act.
+
+It does not mean treating every application as an art project or forcing personality into places where it does not belong. It means refusing to believe that function exhausts the value of what we make. It means caring not only about whether something works, but about the manner in which it enters another person’s life.
+
+Essays, paintings, clothes, watches, perfumes, and songs allow us to encounter another person’s way of seeing. Software can do this too. Its expression may be subtler because we experience it through actions rather than observation. We do not merely look at software. We move through it.
+
+Somewhere in that movement, we can feel whether anybody cared.
+
+And sometimes, if they cared enough, it feels like magic.


### PR DESCRIPTION
Essay on taste, style, and why software carries the presence of the people who made it.

- `src/content/blog/your-voice-in-software.md`, published `Aug 30 2026`
- Renders at `/blog/your-voice-in-software/`
- Introduces two new tags: `software`, `aesthetics`

Fixed before commit: the `tags` line used curly quotes, which YAML parsed as literal characters and rendered as `“software”` / `“aesthetics"` on the tags index. Converted to block sequence style to match the other posts.

`pnpm build` passes — page, tag pages, sitemap entry, and OG image all generate.